### PR TITLE
Add support for "rest parameters"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,10 @@ public:
     std::string member_function(const std::string& s) { return "Hello, " + s; }
 };
 
-void println(const std::string& str) { std::cout << str << std::endl; }
+void println(qjs::rest<std::string> args) {
+    for (auto const & arg : args) std::cout << arg << " ";
+    std::cout << "\n";
+}
 
 int main()
 {
@@ -34,15 +37,19 @@ int main()
                 .fun<&MyClass::member_variable>("member_variable")
                 .fun<&MyClass::member_function>("member_function");
         // import module
-        context.eval("import * as my from 'MyModule'; globalThis.my = my;", "<import>", JS_EVAL_TYPE_MODULE);
+        context.eval(R"xxx(
+            import * as my from 'MyModule';
+            globalThis.my = my;
+        )xxx", "<import>", JS_EVAL_TYPE_MODULE);
         // evaluate js code
-        context.eval("let v1 = new my.MyClass();" "\n"
-                     "v1.member_variable = 1;" "\n"
-                     "let v2 = new my.MyClassA([1,2,3]);" "\n"
-                     "function my_callback(str) {" "\n"
-                     "  my.println(v2.member_function(str));" "\n"
-                     "}" "\n"
-        );
+        context.eval(R"xxx(
+            let v1 = new my.MyClass();
+            v1.member_variable = 1;
+            let v2 = new my.MyClassA([1,2,3]);
+            function my_callback(str) {
+              my.println("at callback:", v2.member_function(str));
+            }
+        )xxx");
 
         // callback
         auto cb = (std::function<void(const std::string&)>) context.eval("my_callback");

--- a/test/function_call.cpp
+++ b/test/function_call.cpp
@@ -1,27 +1,56 @@
+#include "quickjs/quickjs.h"
 #include "quickjspp.hpp"
 #include <cstdio>
+#include <string_view>
+
+void qjs_assert(bool cond) {
+    if (!cond) {
+        printf("FAIL\n");
+        throw qjs::exception{};
+    }
+}
+
+void test_not_enough_arguments(qjs::Context & ctx) {
+    std::string msg;
+
+    ctx.global().add("test_fcn", [](int a, int b, int c) {
+        printf("%d %d %d\n", a, b, c);
+    });
+
+    ctx.eval(
+        "try {"
+        "  test_fcn(1);"
+        "  assert(false);"
+        "} catch (err) {"
+        "  assert("
+        "    (err instanceof TypeError) && "
+        "    err.message === 'Expected type 3 arguments but only 1 were provided'"
+        "  );"
+        "}"
+    );
+}
+
+void test_call_with_rest_arguments(qjs::Context & ctx) {
+    ctx.global().add("test_fcn", [](int a, qjs::rest<int> args) {
+        qjs_assert(a == 1);
+        qjs_assert(args.size() == 3);
+        qjs_assert(args[0] == 2);
+        qjs_assert(args[1] == 3);
+        qjs_assert(args[2] == 4);
+    });
+
+    ctx.eval("test_fcn(1,2,3,4);");
+}
 
 int main()
 {
     qjs::Runtime runtime;
     qjs::Context context(runtime);
 
-    std::string msg;
+    context.global().add("assert", &qjs_assert);
 
-    context.global().add("f_with_3_args", [](int a, int b, int c) {
-        printf("%d %d %d\n", a, b, c);
-    });
-
-    try
-    {
-        context.eval("f_with_3_args(1);");
-    }
-    catch(qjs::exception)
-    {
-        msg = (std::string)context.getException();
-    }
-
-    assert(msg == "TypeError: Expected type 3 arguments but only 1 were provided");
+    test_not_enough_arguments(context);
+    test_call_with_rest_arguments(context);
 
     return 0;
 }


### PR DESCRIPTION
Add a C++ equivalent of JS's [rest parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters). This allows implementing in C++ functions taking a variable number of arguments, like `console.log`.

This change introduces a new type: `qjs::rest<T>`, which is basically a `std::vector<T>`.
When a function takes a `qjs::rest` as the last argument, the remaining input arguments are collected in this vector.
En example usage:
```c++
context.global().add("log", [](qjs::rest<std::string> args) {
    for (auto arg : args) {
        std::cout << arg << " ";
    }
    std::cout << "\n";
});

context.eval(R"xxx(
    log("hello", "world", 123);
)xxx")
``` 