### PR TITLE
Avoid any kind of C++ exception from reaching QuickJS's C code

### DIFF
--- a/quickjspp.hpp
+++ b/quickjspp.hpp
@@ -506,7 +506,7 @@ struct unwrap_arg_impl {
     static auto unwrap(JSContext * ctx, int argc, JSValueConst * argv)
     {
         if (size_t(argc) <= I) {
-            JS_ThrowTypeError(ctx, "Expected type %lu arguments but only %d were provided",
+            JS_ThrowTypeError(ctx, "Expected at least %lu arguments but received %d",
                               (unsigned long)NArgs, argc);
             throw exception{};
         }
@@ -838,7 +838,7 @@ struct js_traits<std::shared_ptr<T>>
             int e = JS_NewClass(rt, QJSClassId, &def);
             if(e < 0)
             {
-                JS_ThrowInternalError(ctx, "Cant register class %s", name);
+                JS_ThrowInternalError(ctx, "Can't register class %s", name);
                 throw exception{};
             }
         }
@@ -951,18 +951,19 @@ struct function
     template <typename Functor>
     static function * create(JSRuntime * rt, Functor&& f)
     {
-        auto fptr = static_cast<function *>(js_malloc_rt(rt, sizeof(function) + sizeof(Functor)));
+        using Functor_t = std::decay_t<Functor>;
+        auto fptr = static_cast<function *>(js_malloc_rt(rt, sizeof(function) + sizeof(Functor_t)));
         if(!fptr)
             throw std::bad_alloc{};
         new(fptr) function;
-        auto functorptr = reinterpret_cast<Functor *>(fptr->functor);
-        new(functorptr) Functor(std::forward<Functor>(f));
+        auto functorptr = reinterpret_cast<Functor_t *>(fptr->functor);
+        new(functorptr) Functor_t(std::forward<Functor>(f));
         fptr->destroyer = nullptr;
-        if constexpr(!std::is_trivially_destructible_v<Functor>)
+        if constexpr(!std::is_trivially_destructible_v<Functor_t>)
         {
             fptr->destroyer = [](function * fptr) {
-                auto functorptr = static_cast<Functor *>(fptr->functor);
-                functorptr->~Functor();
+                auto functorptr = reinterpret_cast<Functor_t *>(fptr->functor);
+                functorptr->~Functor_t();
             };
         }
         return fptr;
@@ -1685,7 +1686,7 @@ struct js_traits<std::function<R(Args...)>>
         auto fptr = function::create(JS_GetRuntime(ctx), std::forward<Functor>(functor));
         fptr->invoker = [](function * self, JSContext * ctx, JSValueConst this_value, int argc, JSValueConst * argv) {
             assert(self);
-            auto f = reinterpret_cast<Functor *>(&self->functor);
+            auto f = reinterpret_cast<std::decay_t<Functor> *>(&self->functor);
             return detail::wrap_call<R, Args...>(ctx, *f, argc, argv);
         };
         JS_SetOpaque(obj, fptr);

--- a/test/exception.cpp
+++ b/test/exception.cpp
@@ -1,7 +1,18 @@
 #include "quickjspp.hpp"
 #include <iostream>
+#include <stdexcept>
 
 struct A{};
+
+struct B {
+    B() {
+        throw std::runtime_error("constructor error");
+    }
+    B(int) {}
+    void a_method() {
+        throw std::runtime_error("method error");
+    }
+};
 
 int main()
 {
@@ -12,6 +23,13 @@ int main()
     context.registerClass<A>("A");
     context.registerClass<A>("A");
 
+    auto& testMod = context.addModule("test");
+
+    testMod.class_<B>("B")
+        .constructor<>("B")
+        .constructor<int>("B_int")
+        .fun<&B::a_method>("a_method");
+
     try
     {
         auto obj = context.eval("Symbol.toPrimitive");
@@ -21,6 +39,9 @@ int main()
     catch(qjs::exception)
     {
         auto exc = context.getException();
+        std::cerr << (exc.isError() ? "Error: " : "Throw: ") << (std::string)exc << std::endl;
+        if((bool)exc["stack"])
+            std::cerr << (std::string)exc["stack"] << std::endl;
         assert(exc.isError() && (std::string) exc == "TypeError: cannot convert symbol to number");
     }
 
@@ -34,7 +55,10 @@ int main()
     catch(qjs::exception)
     {
         auto exc = context.getException();
-        std::cout << (std::string) exc << '\n' << (std::string_view) exc["stack"];
+        std::cerr << (exc.isError() ? "Error: " : "Throw: ") << (std::string)exc << std::endl;
+        if((bool)exc["stack"])
+            std::cerr << (std::string)exc["stack"] << std::endl;
+        assert(exc.isError() && (std::string) exc == "TypeError: cannot convert symbol to number");
     }
 
     try
@@ -50,8 +74,10 @@ int main()
         std::cerr << (exc.isError() ? "Error: " : "Throw: ") << (std::string)exc << std::endl;
         if((bool)exc["stack"])
             std::cerr << (std::string)exc["stack"] << std::endl;
+        assert(exc.isError() && (std::string) exc == "ReferenceError: 'b' is not defined");
     }
 
+    // test the `wrap_call` case
     try
     {
         qjs::Value caller = context.eval("(f) => f();", "<test>");
@@ -66,6 +92,43 @@ int main()
         std::cerr << (exc.isError() ? "Error: " : "Throw: ") << (std::string)exc << std::endl;
         if((bool)exc["stack"])
             std::cerr << (std::string)exc["stack"] << std::endl;
+        assert(exc.isError() && (std::string) exc == "InternalError: some error");
     }
 
+    // test the `ctor_wrapper` case
+    try
+    {
+        qjs::Value caller = context.eval(R"xxx(
+            import { B } from "test";
+            const b = new B();
+        )xxx", "<eval>", JS_EVAL_TYPE_MODULE);
+        assert(false);
+    }
+    catch(qjs::exception)
+    {
+        auto exc = context.getException();
+        std::cerr << (exc.isError() ? "Error: " : "Throw: ") << (std::string)exc << std::endl;
+        if((bool)exc["stack"])
+            std::cerr << (std::string)exc["stack"] << std::endl;
+        assert(exc.isError() && (std::string) exc == "InternalError: constructor error");
+    }
+
+    // test the `wrap_this_call` case
+    try
+    {
+        qjs::Value caller = context.eval(R"xxx(
+            import { B_int } from "test";
+            const b = new B_int(123);
+            b.a_method();
+        )xxx", "<eval>", JS_EVAL_TYPE_MODULE);
+        assert(false);
+    }
+    catch(qjs::exception)
+    {
+        auto exc = context.getException();
+        std::cerr << (exc.isError() ? "Error: " : "Throw: ") << (std::string)exc << std::endl;
+        if((bool)exc["stack"])
+            std::cerr << (std::string)exc["stack"] << std::endl;
+        assert(exc.isError() && (std::string) exc == "InternalError: method error");
+    }
 }

--- a/test/exception.cpp
+++ b/test/exception.cpp
@@ -52,4 +52,20 @@ int main()
             std::cerr << (std::string)exc["stack"] << std::endl;
     }
 
+    try
+    {
+        qjs::Value caller = context.eval("(f) => f();", "<test>");
+        caller.as<std::function<void(std::function<void()>)>>()([](){
+            throw std::runtime_error("some error");
+        });
+        assert(false);
+    }
+    catch(qjs::exception)
+    {
+        auto exc = context.getException();
+        std::cerr << (exc.isError() ? "Error: " : "Throw: ") << (std::string)exc << std::endl;
+        if((bool)exc["stack"])
+            std::cerr << (std::string)exc["stack"] << std::endl;
+    }
+
 }

--- a/test/function_call.cpp
+++ b/test/function_call.cpp
@@ -30,7 +30,7 @@ int test_not_enough_arguments(qjs::Context & ctx) {
                 assert(false);
             } catch (err) {
                 assert(err instanceof TypeError); 
-                assert_eq(err.message, 'Expected type 3 arguments but only 1 were provided');
+                assert_eq(err.message, 'Expected at least 3 arguments but received 1');
             }
         )xxx");
     }


### PR DESCRIPTION
If a wrapped C++ function throws a `qjs::exception`, that is correctly caught and converted to a JS exception.
However, if the wrapped C++ code throws any other kind of exception, that reaches C code, which results in a `std::abort`.

This change adds catch statements to convert other types of exceptions to JS's `InternalError`s.

There's also a small fix in `function::create` needed to make the tests compile.