### PR TITLE
Expose job enqueueing / running API

### DIFF
--- a/quickjspp.hpp
+++ b/quickjspp.hpp
@@ -1698,7 +1698,7 @@ struct js_traits<std::function<R(Args...)>>
         const int argc = sizeof...(Args);
         if constexpr(argc == 0)
         {
-            return [jsfun_obj = Value{ctx, JS_DupValue(ctx, fun_obj)}]() -> R {
+            return [ctx, jsfun_obj = Value{ctx, JS_DupValue(ctx, fun_obj)}]() -> R {
                 JSValue result = JS_Call(jsfun_obj.ctx, jsfun_obj.v, JS_UNDEFINED, 0, nullptr);
                 if(JS_IsException(result))
                 {
@@ -1710,7 +1710,7 @@ struct js_traits<std::function<R(Args...)>>
         }
         else
         {
-            return [jsfun_obj = Value{ctx, JS_DupValue(ctx, fun_obj)}](Args&& ... args) -> R {
+            return [ctx, jsfun_obj = Value{ctx, JS_DupValue(ctx, fun_obj)}](Args&& ... args) -> R {
                 const int argc = sizeof...(Args);
                 JSValue argv[argc];
                 detail::wrap_args(jsfun_obj.ctx, argv, std::forward<Args>(args)...);

--- a/quickjspp.hpp
+++ b/quickjspp.hpp
@@ -1916,7 +1916,7 @@ inline void Context::enqueueJob(std::function<void()> && job_fcn) {
     }, 1, &job_val);
 }
 
-Context & exception::context() const {
+inline Context & exception::context() const {
     return Context::get(ctx);
 }
 

--- a/quickjspp.hpp
+++ b/quickjspp.hpp
@@ -1369,7 +1369,7 @@ public:
         JS_FreeRuntime(rt);
     }
 
-    Context &executePendingJob();
+    Context * executePendingJob();
 
     bool isJobPending() const {
         return JS_IsJobPending(rt);
@@ -1920,14 +1920,16 @@ inline Context & exception::context() const {
     return Context::get(ctx);
 }
 
-inline Context &Runtime::executePendingJob() {
+inline Context * Runtime::executePendingJob() {
     JSContext * ctx;
     auto err = JS_ExecutePendingJob(rt, &ctx);
-    assert(ctx && "The context of the job was NULL");
-    if (err < 0) {
+    if (err == 0) {
+        // There was no job to run
+        return nullptr;
+    } else if (err < 0) {
         throw exception{ctx};
     }
-    return Context::get(ctx);
+    return &Context::get(ctx);
 }
 
 } // namespace qjs

--- a/quickjspp.hpp
+++ b/quickjspp.hpp
@@ -1369,6 +1369,7 @@ public:
         JS_FreeRuntime(rt);
     }
 
+    /// @return pointer to qjs::Context of the executed job or nullptr if no job is pending
     Context * executePendingJob();
 
     bool isJobPending() const {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@ target_compile_definitions(${name}-checkjsv PRIVATE CONFIG_CHECK_JSVALUE=1)
 endmacro()
 
 foreach(test
-        value class exception example multicontext conversions point variant function_call inheritance
+        value class exception example multicontext conversions point variant function_call inheritance jobs
         )
 make_test(${test})
 endforeach()

--- a/test/jobs.cpp
+++ b/test/jobs.cpp
@@ -40,6 +40,9 @@ int main()
     } catch (qjs::exception const & exc) {
         assert(&exc.context() == &context && "Exception should contain context information");
     }
-
+    // Check that not executed jobs won't introduce memory leaks
+    context.enqueueJob([](){
+        assert(false && "This job will not be called");
+    });
     return 0;
 }

--- a/test/jobs.cpp
+++ b/test/jobs.cpp
@@ -28,5 +28,18 @@ int main()
 
     assert(called && "`testFcn` should have been called");
 
+    context.enqueueJob([](){
+        throw std::runtime_error("some error");
+    });
+
+    try {
+        while (runtime.isJobPending()) {
+            runtime.executePendingJob();
+        }
+        assert(false && "Job execution should have failed");
+    } catch (qjs::exception const & exc) {
+        assert(&exc.context() == &context && "Exception should contain context information");
+    }
+
     return 0;
 }

--- a/test/jobs.cpp
+++ b/test/jobs.cpp
@@ -1,0 +1,32 @@
+#include "quickjspp.hpp"
+#include <iostream>
+#include <stdexcept>
+
+int main()
+{
+    qjs::Runtime runtime;
+    qjs::Context context(runtime);
+    
+    context.global().add("nextTick", [&context](std::function<void()> f) {
+        context.enqueueJob(std::move(f));
+    });
+
+    bool called = false;
+    context.global().add("testFcn", [&called]() {
+        called = true;
+    });
+
+    qjs::Value caller = context.eval(R"xxx(
+        nextTick(testFcn);
+    )xxx");
+
+    assert(!called && "`testFcn` should not be called yet");
+
+    while (runtime.isJobPending()) {
+        runtime.executePendingJob();
+    }
+
+    assert(called && "`testFcn` should have been called");
+
+    return 0;
+}

--- a/test/variant.cpp
+++ b/test/variant.cpp
@@ -1,4 +1,5 @@
 #include "quickjspp.hpp"
+#include <stdexcept>
 #include <variant>
 #include <iostream>
 
@@ -40,7 +41,7 @@ auto f2(var2 v2) -> var
 
 void assert_(bool condition)
 {
-    if(!condition) throw qjs::exception{};
+    if(!condition) throw std::runtime_error("assertion failed");
 }
 
 static void qjs_glue(qjs::Context::Module& m)


### PR DESCRIPTION
Expose QuickJS's API to enqueue and run jobs in the context.

The job running API is part of the `JSRuntime`, and returns as output the JSContext that the job is part of.
Enabling multi-context workflows requires adding context information to `exception`.