### PR TITLE
Expose API to detect unhandled Promise rejections

### DIFF
--- a/quickjs/patches/unhandled_rejection.patch
+++ b/quickjs/patches/unhandled_rejection.patch
@@ -1,0 +1,72 @@
+diff --git a/quickjs/quickjs.c b/quickjs/quickjs.c
+index 8afc4ca..c3f98e2 100644
+--- a/quickjs/quickjs.c
++++ b/quickjs/quickjs.c
+@@ -282,6 +282,9 @@ struct JSRuntime {
+ 
+     JSHostPromiseRejectionTracker *host_promise_rejection_tracker;
+     void *host_promise_rejection_tracker_opaque;
++
++    JSHostPromiseRejectionTracker *host_unhandled_promise_rejection_tracker;
++    void *host_unhandled_promise_rejection_tracker_opaque;
+     
+     struct list_head job_list; /* list of JSJobEntry.link */
+ 
+@@ -46255,6 +46258,7 @@ typedef struct JSPromiseData {
+     struct list_head promise_reactions[2];
+     BOOL is_handled; /* Note: only useful to debug */
+     JSValue promise_result;
++    JSContext * ctx;
+ } JSPromiseData;
+ 
+ typedef struct JSPromiseFunctionDataResolved {
+@@ -46335,6 +46339,14 @@ void JS_SetHostPromiseRejectionTracker(JSRuntime *rt,
+     rt->host_promise_rejection_tracker_opaque = opaque;
+ }
+ 
++void JS_SetHostUnhandledPromiseRejectionTracker(JSRuntime *rt,
++                                       JSHostPromiseRejectionTracker *cb,
++                                       void *opaque)
++{
++    rt->host_unhandled_promise_rejection_tracker = cb;
++    rt->host_unhandled_promise_rejection_tracker_opaque = opaque;
++}
++
+ static void fulfill_or_reject_promise(JSContext *ctx, JSValueConst promise,
+                                       JSValueConst value, BOOL is_reject)
+ {
+@@ -46539,6 +46551,14 @@ static void js_promise_finalizer(JSRuntime *rt, JSValue val)
+ 
+     if (!s)
+         return;
++
++    if (s->promise_state == JS_PROMISE_REJECTED && !s->is_handled) {
++        if (rt->host_unhandled_promise_rejection_tracker) {
++            rt->host_unhandled_promise_rejection_tracker(s->ctx, val, s->promise_result, FALSE,
++                                                         rt->host_unhandled_promise_rejection_tracker_opaque);
++        }
++    }
++
+     for(i = 0; i < 2; i++) {
+         list_for_each_safe(el, el1, &s->promise_reactions[i]) {
+             JSPromiseReactionData *rd =
+@@ -46589,6 +46609,7 @@ static JSValue js_promise_constructor(JSContext *ctx, JSValueConst new_target,
+     s = js_mallocz(ctx, sizeof(*s));
+     if (!s)
+         goto fail;
++    s->ctx = ctx;
+     s->promise_state = JS_PROMISE_PENDING;
+     s->is_handled = FALSE;
+     for(i = 0; i < 2; i++)
+diff --git a/quickjs/quickjs.h b/quickjs/quickjs.h
+index 0540191..215e7b2 100644
+--- a/quickjs/quickjs.h
++++ b/quickjs/quickjs.h
+@@ -839,6 +839,7 @@ typedef void JSHostPromiseRejectionTracker(JSContext *ctx, JSValueConst promise,
+                                            JSValueConst reason,
+                                            JS_BOOL is_handled, void *opaque);
+ void JS_SetHostPromiseRejectionTracker(JSRuntime *rt, JSHostPromiseRejectionTracker *cb, void *opaque);
++void JS_SetHostUnhandledPromiseRejectionTracker(JSRuntime *rt, JSHostPromiseRejectionTracker *cb, void *opaque);
+ 
+ /* return != 0 if the JS code needs to be interrupted */
+ typedef int JSInterruptHandler(JSRuntime *rt, void *opaque);

--- a/quickjs/quickjs.c
+++ b/quickjs/quickjs.c
@@ -282,6 +282,9 @@ struct JSRuntime {
 
     JSHostPromiseRejectionTracker *host_promise_rejection_tracker;
     void *host_promise_rejection_tracker_opaque;
+
+    JSHostPromiseRejectionTracker *host_unhandled_promise_rejection_tracker;
+    void *host_unhandled_promise_rejection_tracker_opaque;
     
     struct list_head job_list; /* list of JSJobEntry.link */
 
@@ -46255,6 +46258,7 @@ typedef struct JSPromiseData {
     struct list_head promise_reactions[2];
     BOOL is_handled; /* Note: only useful to debug */
     JSValue promise_result;
+    JSContext * ctx;
 } JSPromiseData;
 
 typedef struct JSPromiseFunctionDataResolved {
@@ -46333,6 +46337,14 @@ void JS_SetHostPromiseRejectionTracker(JSRuntime *rt,
 {
     rt->host_promise_rejection_tracker = cb;
     rt->host_promise_rejection_tracker_opaque = opaque;
+}
+
+void JS_SetHostUnhandledPromiseRejectionTracker(JSRuntime *rt,
+                                       JSHostPromiseRejectionTracker *cb,
+                                       void *opaque)
+{
+    rt->host_unhandled_promise_rejection_tracker = cb;
+    rt->host_unhandled_promise_rejection_tracker_opaque = opaque;
 }
 
 static void fulfill_or_reject_promise(JSContext *ctx, JSValueConst promise,
@@ -46539,6 +46551,14 @@ static void js_promise_finalizer(JSRuntime *rt, JSValue val)
 
     if (!s)
         return;
+
+    if (s->promise_state == JS_PROMISE_REJECTED && !s->is_handled) {
+        if (rt->host_unhandled_promise_rejection_tracker) {
+            rt->host_unhandled_promise_rejection_tracker(s->ctx, val, s->promise_result, FALSE,
+                                                         rt->host_unhandled_promise_rejection_tracker_opaque);
+        }
+    }
+
     for(i = 0; i < 2; i++) {
         list_for_each_safe(el, el1, &s->promise_reactions[i]) {
             JSPromiseReactionData *rd =
@@ -46589,6 +46609,7 @@ static JSValue js_promise_constructor(JSContext *ctx, JSValueConst new_target,
     s = js_mallocz(ctx, sizeof(*s));
     if (!s)
         goto fail;
+    s->ctx = ctx;
     s->promise_state = JS_PROMISE_PENDING;
     s->is_handled = FALSE;
     for(i = 0; i < 2; i++)

--- a/quickjs/quickjs.h
+++ b/quickjs/quickjs.h
@@ -839,6 +839,7 @@ typedef void JSHostPromiseRejectionTracker(JSContext *ctx, JSValueConst promise,
                                            JSValueConst reason,
                                            JS_BOOL is_handled, void *opaque);
 void JS_SetHostPromiseRejectionTracker(JSRuntime *rt, JSHostPromiseRejectionTracker *cb, void *opaque);
+void JS_SetHostUnhandledPromiseRejectionTracker(JSRuntime *rt, JSHostPromiseRejectionTracker *cb, void *opaque);
 
 /* return != 0 if the JS code needs to be interrupted */
 typedef int JSInterruptHandler(JSRuntime *rt, void *opaque);

--- a/quickjspp.hpp
+++ b/quickjspp.hpp
@@ -1604,6 +1604,7 @@ public:
         JS_FreeContext(ctx);
     }
 
+    /** Callback triggered when a Promise rejection won't ever be handled */
     std::function<void(Value)> onUnhandledPromiseRejection;
 
     template <typename Function>

--- a/quickjspp.hpp
+++ b/quickjspp.hpp
@@ -1355,6 +1355,8 @@ public:
         rt = JS_NewRuntime();
         if(!rt)
             throw std::runtime_error{"qjs: Cannot create runtime"};
+        
+        JS_SetHostUnhandledPromiseRejectionTracker(rt, promise_unhandled_rejection_tracker, NULL);
     }
 
     // noncopyable
@@ -1371,6 +1373,10 @@ public:
     bool isJobPending() const {
         return JS_IsJobPending(rt);
     }
+
+private:
+    static void promise_unhandled_rejection_tracker(JSContext *ctx, JSValueConst promise,
+                                                    JSValueConst reason, JS_BOOL is_handled, void *opaque);
 };
 
 /** Wrapper over JSContext * ctx
@@ -1597,6 +1603,8 @@ public:
         modules.clear();
         JS_FreeContext(ctx);
     }
+
+    std::function<void(Value)> onUnhandledPromiseRejection;
 
     template <typename Function>
     void enqueueJob(Function && job);
@@ -1919,6 +1927,15 @@ void Context::enqueueJob(Function && job) {
 
 inline Context & exception::context() const {
     return Context::get(ctx);
+}
+
+inline void Runtime::promise_unhandled_rejection_tracker(JSContext *ctx, JSValueConst promise,
+                                                         JSValueConst reason, JS_BOOL is_handled, void *opaque)
+{
+    auto & context = Context::get(ctx);
+    if (context.onUnhandledPromiseRejection) {
+        context.onUnhandledPromiseRejection(context.newValue(JS_DupValue(ctx, reason)));
+    }
 }
 
 inline Context * Runtime::executePendingJob() {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(${name}-checkjsv quickjspp)
 endmacro()
 
 foreach(test
-        value class exception example multicontext conversions point variant function_call inheritance jobs
+        value class exception example multicontext conversions point variant function_call inheritance jobs unhandled_rejection
         )
 make_test(${test})
 endforeach()

--- a/test/unhandled_rejection.cpp
+++ b/test/unhandled_rejection.cpp
@@ -1,0 +1,79 @@
+#include "quickjspp.hpp"
+#include <iostream>
+#include <stdexcept>
+
+int main()
+{
+    qjs::Runtime runtime;
+    qjs::Context context(runtime);
+    
+    context.global().add("nextTick", [&context](std::function<void()> f) {
+        context.enqueueJob(std::move(f));
+    });
+
+    bool called = false;
+    context.onUnhandledPromiseRejection = [&called](qjs::Value reason) {
+        called = true;
+    };
+
+    // Catch the rejection
+    called = false;
+    context.eval(R"xxx(
+        (() => {
+            const p = new Promise((resolve, reject) => {
+                nextTick(() => {
+                    reject(123);
+                })
+            });
+            p.catch(() => {/* no-op */});
+        })();
+    )xxx");
+
+    while (runtime.isJobPending()) {
+        runtime.executePendingJob();
+    }
+
+    assert(!called && "Unhandled Promise rejection should not have been called");
+
+    // Catch the rejection, but only one *after* it happens.
+    called = false;
+    context.eval(R"xxx(
+        (() => {
+            const p = new Promise((resolve, reject) => {
+                reject(123);
+                nextTick(() => {
+                    p.catch(() => {/* no-op */});
+                });
+            });
+        })();
+    )xxx");
+
+    while (runtime.isJobPending()) {
+        runtime.executePendingJob();
+    }
+
+    assert(!called && "Unhandled Promise rejection should not have been called");
+
+    // Do not catch the rejection
+    called = false;
+    context.eval(R"xxx(
+        (() => {
+            const p = new Promise((resolve, reject) => {
+                reject(123);
+                nextTick(() => {
+                    p.then(() => {/* no-op */})
+                });
+            });
+        })();
+    )xxx");
+
+    assert(!called && "Unhandled Promise rejection should not have been called yet");
+
+    while (runtime.isJobPending()) {
+        runtime.executePendingJob();
+    }
+
+    assert(called && "Unhandled Promise rejection should have been called");
+
+    return 0;
+}


### PR DESCRIPTION
The intention of this change is to expose the `JS_SetHostPromiseRejectionTracker` API.
Unfortunately, that API triggers the moment the promise rejects, which doesn't necessarily mean it's unhandled.

This change adds a patch to QuickJS to add a new `JS_SetHostUnhandledPromiseRejectionTracker` API, which triggers only when the promise is rejected and won't ever be handled (by hooking into the Promise finalizer).
The API is exposed to C++ in the form of a callback in the `Context` class.

I don't know how happy you are with adding patches to QuickJS. I would prefer not to, so I tried to keep it as minimal as possible.