### PR TITLE
Expose the module loader API

### DIFF
--- a/qjs.cpp
+++ b/qjs.cpp
@@ -1,5 +1,5 @@
 #include "quickjspp.hpp"
-
+#include "quickjs/quickjs-libc.h"
 
 #include <iostream>
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(${name}-checkjsv quickjspp)
 endmacro()
 
 foreach(test
-        value class exception example multicontext conversions point variant function_call inheritance jobs unhandled_rejection
+        value class exception example multicontext conversions point variant function_call inheritance jobs unhandled_rejection module_loader
         )
 make_test(${test})
 endforeach()

--- a/test/class.cpp
+++ b/test/class.cpp
@@ -1,4 +1,5 @@
 #include "quickjspp.hpp"
+#include "quickjs/quickjs-libc.h"
 #include <iostream>
 
 

--- a/test/module_loader.cpp
+++ b/test/module_loader.cpp
@@ -1,0 +1,53 @@
+#include "quickjspp.hpp"
+#include <iostream>
+
+int main()
+{
+    qjs::Runtime runtime;
+    qjs::Context context(runtime);
+
+    auto simple_module_loader = [](char const * filename) -> qjs::Context::ModuleDataOpt {
+        if (filename == std::string_view("some_module.js")) {
+            return qjs::Context::ModuleData{R"xxx(
+                import "folder/file1.js"
+                log(import.meta.url);
+            )xxx"};
+        }
+        if (filename == std::string_view("folder/file1.js")) {
+            return qjs::Context::ModuleData{R"xxx(
+                import "./file2.js"
+                log(import.meta.url);
+            )xxx"};
+        }
+        if (filename == std::string_view("folder/file2.js")) {
+            return qjs::Context::ModuleData{R"xxx(
+                log(import.meta.url);
+            )xxx"};
+        }
+        return std::nullopt;
+    };
+
+    context.moduleLoader = simple_module_loader;
+    context.global().add("log", [](std::string_view s) {
+        std::cout << s << std::endl;
+    });
+
+    context.eval(R"xxx(
+        import "./some_module.js";
+    )xxx", "<eval>", JS_EVAL_TYPE_MODULE);
+
+    try {
+        context.eval(R"xxx(
+            import "./invalid_module.js";
+        )xxx", "<eval>", JS_EVAL_TYPE_MODULE);
+        assert(false && "module import should have failed");
+    }
+    catch(qjs::exception e)
+    {
+        auto exc = e.get();
+        assert(exc.isError() && "Exception should be a JS error");
+        assert((std::string)exc == "ReferenceError: could not load module filename 'invalid_module.js'");
+    }
+
+    return 0;
+}

--- a/test/module_loader.cpp
+++ b/test/module_loader.cpp
@@ -7,48 +7,75 @@ int main()
     qjs::Runtime runtime;
     qjs::Context context(runtime);
 
-    auto simple_module_loader = [](std::string_view filename) -> qjs::Context::ModuleData {
-        if (filename == "some_module.js") {
-            return {R"xxx(
+    std::unordered_map<std::string_view, std::string> files = {
+        {
+            "some_module.js",
+            R"xxx(
                 import "folder/file1.js"
                 log(import.meta.url);
-            )xxx"};
-        }
-        if (filename == "folder/file1.js") {
-            return {R"xxx(
+            )xxx"
+        },
+        {
+            "folder/file1.js",
+            R"xxx(
                 import "./file2.js"
                 log(import.meta.url);
-            )xxx"};
-        }
-        if (filename == "folder/file2.js") {
-            return {R"xxx(
+            )xxx"
+        },
+        {
+            "folder/file2.js",
+            R"xxx(
                 import "http://localhost/script1.js";
                 log(import.meta.url);
-            )xxx"};
-        }
-        if (filename == "http://localhost/script1.js") {
-            return {R"xxx(
+            )xxx"
+        },
+        {
+            "http://localhost/script1.js",
+            R"xxx(
                 import "./script2.js";
                 log(import.meta.url);
-            )xxx"};
-        }
-        if (filename == "http://localhost/script2.js") {
-            return {R"xxx(
+            )xxx"
+        },
+        {
+            "http://localhost/script2.js",
+            R"xxx(
                 log(import.meta.url);
-            )xxx"};
-        }
+            )xxx"
+        },
+    };
+
+    auto mock_module_loader = [&files](std::string_view filename) -> qjs::Context::ModuleData {
+        if (files.count(filename)) return { qjs::detail::toUri(filename), files.at(filename) };
         return {};
     };
 
-    context.moduleLoader = simple_module_loader;
+    // Test a failing import with the default moduleLoader
+    try
+    {
+        context.eval(R"xxx(
+            import "./invalid_module.js";
+        )xxx", "<eval>", JS_EVAL_TYPE_MODULE);
+        assert(false && "module import should have failed");
+    }
+    catch(qjs::exception e)
+    {
+        auto exc = e.get();
+        assert(exc.isError() && "Exception should be a JS error");
+        assert((std::string)exc == "ReferenceError: could not load module filename 'invalid_module.js'");
+    }
+
+    context.moduleLoader = mock_module_loader;
     context.global().add("log", [](std::string_view s) {
         std::cout << s << std::endl;
     });
 
+    // Test a successful import with the mock moduleLoader
+    // It pretends to import things from the filesystem and from URLs
     context.eval(R"xxx(
         import "./some_module.js";
     )xxx", "<eval>", JS_EVAL_TYPE_MODULE);
 
+    // Test a failing import with the mock moduleLoader
     try
     {
         context.eval(R"xxx(


### PR DESCRIPTION
Expose the module loader API and remove dependency on `quickjs-libc` from the main `quickjspp.hpp` header file.