### PR TITLE
Fix build on Windows and Linux gcc-8

### DIFF
--- a/.github/workflows/cxx.yml
+++ b/.github/workflows/cxx.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [linux-gcc,linux-clang,linux-gcc8,linux-gcc10,linux-gcc-ubsan,linux-gcc-asan,linux-gcc-32,linux-gcc-x32,linux-clang11,linux-clang12,windows-gcc,macos-clang]
+        compiler: [linux-gcc,linux-clang,linux-gcc8,linux-gcc10,linux-gcc-ubsan,linux-gcc-asan,linux-gcc-32,linux-gcc-x32,linux-clang11,linux-clang12,macos-clang]
         build_type: [Debug]
         include:
           - compiler: linux-gcc
@@ -21,7 +21,7 @@ jobs:
           - compiler: linux-gcc8
             os: ubuntu-18.04
             preconfigure: sudo apt-get update && sudo apt-get install -y gcc-8 g++-8
-            cmake_opts: -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8
+            cmake_opts: -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8 -DCMAKE_REQUIRED_LIBRARIES=stdc++fs
 
           - compiler: linux-gcc10
             os: ubuntu-20.04
@@ -58,13 +58,6 @@ jobs:
             cmake_opts: -DCMAKE_C_COMPILER=clang-12 -DCMAKE_CXX_COMPILER=clang++-12
             cflags: -stdlib=libc++
 
-#          - compiler: windows-msvs # not supported
-#            os: windows-latest
-
-          - compiler: windows-gcc
-            os: windows-2019
-            cmake_opts: -G "MSYS Makefiles" -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
-
           - compiler: macos-clang
             os: macos-latest
 
@@ -72,6 +65,47 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
+    - name: preconfigure
+      run: ${{ matrix.preconfigure }}
+    - name: configure
+      run: cmake -S . -B build_dir -Wdev -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_C_FLAGS="${{ matrix.cflags }}" -DCMAKE_CXX_FLAGS="${{ matrix.cflags }}" -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.cflags }}" ${{ matrix.cmake_opts }}
+    - name: build
+      run: cmake --build build_dir --verbose
+    - name: test
+      run: ctest --extra-verbose
+      working-directory: build_dir
+      env:
+        # extra options for address sanitizer
+        ASAN_OPTIONS: strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1
+
+  build_windows:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [windows-gcc]
+        build_type: [Debug]
+        include:
+          - compiler: windows-gcc
+            os: windows-2019
+            cmake_opts: -G "Ninja" -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+
+#          - compiler: windows-msvs # not supported
+#            os: windows-latest
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        update: true
+        install: git cmake ninja mingw-w64-x86_64-toolchain mingw-w64-x86_64-dlfcn
     - name: preconfigure
       run: ${{ matrix.preconfigure }}
     - name: configure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 add_subdirectory(quickjs)
 
 add_library(quickjspp INTERFACE)
-target_link_libraries(quickjspp INTERFACE quickjs)
+target_link_libraries(quickjspp INTERFACE quickjs ${CMAKE_REQUIRED_LIBRARIES})
 target_compile_features(quickjspp INTERFACE cxx_std_17)
 target_include_directories(quickjspp INTERFACE .)
 set_target_properties(quickjspp PROPERTIES PUBLIC_HEADER quickjspp.hpp)

--- a/qjs.cpp
+++ b/qjs.cpp
@@ -5,19 +5,15 @@
 
 int main(int argc, char ** argv)
 {
-    JSRuntime * rt;
-    JSContext * ctx;
     using namespace qjs;
 
     Runtime runtime;
-    rt = runtime.rt;
-
     Context context(runtime);
-    ctx = context.ctx;
+
+    auto rt = runtime.rt;
+    auto ctx = context.ctx;
 
     js_std_init_handlers(rt);
-    /* loader for ES6 modules */
-    JS_SetModuleLoaderFunc(rt, nullptr, js_module_loader, nullptr);
     js_std_add_helpers(ctx, argc - 1, argv + 1);
 
     /* system modules */
@@ -25,21 +21,21 @@ int main(int argc, char ** argv)
     js_init_module_os(ctx, "os");
 
     /* make 'std' and 'os' visible to non module code */
-    const char * str = "import * as std from 'std';\n"
-                       "import * as os from 'os';\n"
-                       "globalThis.std = std;\n"
-                       "globalThis.os = os;\n";
-    context.eval(str, "<input>", JS_EVAL_TYPE_MODULE);
+    context.eval(R"xxx(
+        import * as std from 'std';
+        import * as os from 'os';
+        globalThis.std = std;
+        globalThis.os = os;
+    )xxx", "<input>", JS_EVAL_TYPE_MODULE);
 
     try
     {
         if(argv[1])
             context.evalFile(argv[1], JS_EVAL_TYPE_MODULE);
     }
-    catch(exception)
+    catch(exception & e)
     {
-        //js_std_dump_error(ctx);
-        auto exc = context.getException();
+        auto exc = e.get();
         std::cerr << (exc.isError() ? "Error: " : "Throw: ") << (std::string)exc << std::endl;
         if((bool)exc["stack"])
             std::cerr << (std::string)exc["stack"] << std::endl;


### PR DESCRIPTION
This change moves the Windows build from the outdated mingw included with the base Windows image to the msys2 based mingw.

It also adds libstdc++fs to the gcc8 build as that's a requirement for `std::filesystem` in gcc-8.