### PR TITLE
Allow assigning functors to qjs::Value

### DIFF
--- a/quickjspp.hpp
+++ b/quickjspp.hpp
@@ -1746,7 +1746,7 @@ struct js_traits<Value>
  * @tparam Args argument types
  */
 template <typename R, typename... Args>
-struct js_traits<std::function<R(Args...)>>
+struct js_traits<std::function<R(Args...)>, int>
 {
     static auto unwrap(JSContext * ctx, JSValueConst fun_obj)
     {
@@ -1801,6 +1801,39 @@ struct js_traits<std::function<R(Args...)>>
         };
         JS_SetOpaque(obj, fptr);
         return obj;
+    }
+};
+
+namespace detail {
+
+template<typename T, typename = void>
+struct is_callable : std::is_function<T> { };
+
+template<typename T>
+struct is_callable<T, std::enable_if_t<std::is_same_v<decltype(void(&T::operator())), void>>> : std::true_type { };
+
+template<typename T>
+inline constexpr bool is_callable_v = is_callable<T>::value;
+
+}
+
+template <typename Function>
+struct js_traits<Function, std::enable_if_t<detail::is_callable_v<Function>>> {
+    static auto unwrap(JSContext * ctx, JSValueConst fun_obj)
+    {
+        return js_traits<
+            decltype(std::function{std::declval<Function>()}),
+            int
+        >::unwrap(ctx, fun_obj);
+    }
+
+    template <typename Functor>
+    static JSValue wrap(JSContext * ctx, Functor&& functor)
+    {
+        return js_traits<
+            decltype(std::function{std::declval<Function>()}),
+            int
+        >::wrap(ctx, std::forward<Functor>(functor));
     }
 };
 

--- a/quickjspp.hpp
+++ b/quickjspp.hpp
@@ -1544,7 +1544,7 @@ public:
             template <typename F>
             class_registrar& fun(const char * name, F&& f)
             {
-                prototype.add(name, std::forward<F>(f));
+                prototype[name] = std::forward<F>(f);
                 return *this;
             }
 

--- a/test/class.cpp
+++ b/test/class.cpp
@@ -119,7 +119,7 @@ int main()
         context.eval(str, "<input>", JS_EVAL_TYPE_MODULE);
 
 
-        context.global().add("assert", [](bool t) { if(!t) std::exit(2); });
+        context.global()["assert"] = [](bool t) { if(!t) std::exit(2); };
 
 
         auto xxx = context.eval("\"use strict\";"

--- a/test/exception.cpp
+++ b/test/exception.cpp
@@ -18,7 +18,7 @@ int main()
 {
     qjs::Runtime runtime;
     qjs::Context context(runtime);
-    context.global().add("println", [](const std::string& s) { std::cout << s << std::endl; });
+    context.global()["println"] = [](const std::string& s) { std::cout << s << std::endl; };
 
     context.registerClass<A>("A");
     context.registerClass<A>("A");
@@ -47,7 +47,6 @@ int main()
 
     try
     {
-        //context.global().add("emptyf", [](JSValue v) {} );
         auto f = (std::function<void ()>) context.eval("(function() { +Symbol.toPrimitive })");
         f();
         assert(false);

--- a/test/function_call.cpp
+++ b/test/function_call.cpp
@@ -6,9 +6,9 @@
 int test_not_enough_arguments(qjs::Context & ctx) {
     std::string msg;
 
-    ctx.global().add("test_fcn", [](int a, int b, int c) {
+    ctx.global()["test_fcn"] = [](int a, int b, int c) {
         return a + b + c;
-    });
+    };
 
     try
     {
@@ -47,19 +47,19 @@ int test_not_enough_arguments(qjs::Context & ctx) {
 }
 
 int test_call_with_rest_parameters(qjs::Context & ctx) {
-    ctx.global().add("test_fcn_rest", [](int a, qjs::rest<int> args) {
+    ctx.global()["test_fcn_rest"] = [](int a, qjs::rest<int> args) {
         for (auto arg : args) {
             a += arg;
         }
         return a;
-    });
+    };
 
-    ctx.global().add("test_fcn_vec", [](int a, std::vector<int> args) {
+    ctx.global()["test_fcn_vec"] = [](int a, std::vector<int> args) {
         for (auto arg : args) {
             a += arg;
         }
         return a;
-    });
+    };
 
     try
     {

--- a/test/jobs.cpp
+++ b/test/jobs.cpp
@@ -7,14 +7,14 @@ int main()
     qjs::Runtime runtime;
     qjs::Context context(runtime);
     
-    context.global().add("nextTick", [&context](std::function<void()> f) {
+    context.global()["nextTick"] = [&context](std::function<void()> f) {
         context.enqueueJob(std::move(f));
-    });
+    };
 
     bool called = false;
-    context.global().add("testFcn", [&called]() {
+    context.global()["testFcn"] = [&called]() {
         called = true;
-    });
+    };
 
     qjs::Value caller = context.eval(R"xxx(
         nextTick(testFcn);

--- a/test/module_loader.cpp
+++ b/test/module_loader.cpp
@@ -41,9 +41,9 @@ int main()
     };
 
     context.moduleLoader = simple_module_loader;
-    context.global().add("log", [](std::string_view s) {
+    context.global()["log"] = [](std::string_view s) {
         std::cout << s << std::endl;
-    });
+    };;
 
     context.eval(R"xxx(
         import "./some_module.js";

--- a/test/unhandled_rejection.cpp
+++ b/test/unhandled_rejection.cpp
@@ -7,9 +7,9 @@ int main()
     qjs::Runtime runtime;
     qjs::Context context(runtime);
     
-    context.global().add("nextTick", [&context](std::function<void()> f) {
+    context.global()["nextTick"] = [&context](std::function<void()> f) {
         context.enqueueJob(std::move(f));
-    });
+    };
 
     bool called = false;
     context.onUnhandledPromiseRejection = [&called](qjs::Value reason) {


### PR DESCRIPTION
Add a `js_trait` for callable objects that redirects `wrap` and `unwrap` to the correct js_trait for `std::function`.