### PR TITLE
quickjspp v2

### DIFF
--- a/quickjspp.hpp
+++ b/quickjspp.hpp
@@ -1166,7 +1166,7 @@ public:
     {
         assert(buffer.data()[buffer.size()] == '\0' && "eval buffer is not null-terminated"); // JS_Eval requirement
         assert(ctx);
-        return Value{ctx, JS_EvalThis(ctx, JS_DupValue(ctx, v), buffer.data(), buffer.size(), filename, flags)};
+        return Value{ctx, JS_EvalThis(ctx, v, buffer.data(), buffer.size(), filename, flags)};
     }
 
     void swap(Value& r) noexcept { std::swap(this->ctx, r.ctx); std::swap(this->v, r.v); }

--- a/quickjspp.hpp
+++ b/quickjspp.hpp
@@ -65,13 +65,13 @@ struct js_traits
      * @param v This value is passed as JSValueConst so it should be freed by the caller.
      * @throws exception in case of conversion error
      */
-    static R unwrap(JSContext * ctx, JSValueConst v);
+    static R unwrap(JSContext * ctx, JSValueConst v) = delete;
 
     /** Create JSValue from an object of type R and JSContext.
      * This function is intentionally not implemented. User should implement this function for their own type.
      * @return Returns JSValue which should be freed by the caller or JS_EXCEPTION in case of error.
      */
-    static JSValue wrap(JSContext * ctx, R value);
+    static JSValue wrap(JSContext * ctx, R value) = delete;
 };
 
 /** Conversion traits for JSValue (identity).
@@ -875,9 +875,9 @@ struct js_traits<detail::function>
 template <typename Key>
 struct js_property_traits
 {
-    static void set_property(JSContext * ctx, JSValue this_obj, Key key, JSValue value);
+    static void set_property(JSContext * ctx, JSValue this_obj, Key key, JSValue value) = delete;
 
-    static JSValue get_property(JSContext * ctx, JSValue this_obj, Key key);
+    static JSValue get_property(JSContext * ctx, JSValue this_obj, Key key) = delete;
 };
 
 template <>

--- a/quickjspp.hpp
+++ b/quickjspp.hpp
@@ -1864,19 +1864,16 @@ struct js_traits<std::function<R(Args...)>, int>
         const int argc = sizeof...(Args);
         if constexpr(argc == 0)
         {
-            return [ctx, jsfun_obj = Value{ctx, JS_DupValue(ctx, fun_obj)}]() -> R {
+            return [jsfun_obj = Value{ctx, JS_DupValue(ctx, fun_obj)}]() -> R {
                 JSValue result = JS_Call(jsfun_obj.ctx, jsfun_obj.v, JS_UNDEFINED, 0, nullptr);
                 if(JS_IsException(result))
-                {
-                    JS_FreeValue(jsfun_obj.ctx, result);
-                    throw exception{ctx};
-                }
+                    throw exception{jsfun_obj.ctx};
                 return detail::unwrap_free<R>(jsfun_obj.ctx, result);
             };
         }
         else
         {
-            return [ctx, jsfun_obj = Value{ctx, JS_DupValue(ctx, fun_obj)}](Args&& ... args) -> R {
+            return [jsfun_obj = Value{ctx, JS_DupValue(ctx, fun_obj)}](Args&& ... args) -> R {
                 const int argc = sizeof...(Args);
                 JSValue argv[argc];
                 detail::wrap_args(jsfun_obj.ctx, argv, std::forward<Args>(args)...);
@@ -1884,10 +1881,7 @@ struct js_traits<std::function<R(Args...)>, int>
                                          const_cast<JSValueConst *>(argv));
                 for(int i = 0; i < argc; i++) JS_FreeValue(jsfun_obj.ctx, argv[i]);
                 if(JS_IsException(result))
-                {
-                    JS_FreeValue(jsfun_obj.ctx, result);
-                    throw exception{ctx};
-                }
+                    throw exception{jsfun_obj.ctx};
                 return detail::unwrap_free<R>(jsfun_obj.ctx, result);
             };
         }

--- a/quickjspp.hpp
+++ b/quickjspp.hpp
@@ -1395,8 +1395,12 @@ struct js_traits<qjs::shared_ptr<T>>
                     name,
                     // destructor (finalizer)
                     [](JSRuntime * rt, JSValue obj) noexcept {
-                        auto pptr = static_cast<T *>(JS_GetOpaque(obj, QJSClassId));
-                        delete pptr;
+                        auto ptr = static_cast<T *>(JS_GetOpaque(obj, QJSClassId));
+                        if constexpr(std::is_base_of_v<qjs::enable_shared_from_this<T>, T>)
+                        {
+                            if(ptr) ptr->shared_this.release();
+                        }
+                        delete ptr;
                     },
                     // mark
                     marker,

--- a/quickjspp.hpp
+++ b/quickjspp.hpp
@@ -872,9 +872,7 @@ struct js_traits<std::shared_ptr<T>>
             if(!markOffsets.empty())
             {
                 marker = [](JSRuntime *rt, JSValueConst val, JS_MarkFunc *mark_func) {
-                    auto pptr = static_cast<std::shared_ptr<T> *>(JS_GetOpaque(val, QJSClassId));
-                    assert(pptr);
-                    const T * ptr = pptr->get();
+                    auto ptr = static_cast<const T *>(JS_GetOpaque(val, QJSClassId));
                     assert(ptr);
                     for(Value T::* member : markOffsets)
                     {
@@ -1605,10 +1603,11 @@ public:
             /** All qjs::Value members of T should be marked by mark<> for QuickJS garbage collector
              * so that the cycle removal algorithm can find the other objects referenced by this object.
              */
-            template <Value T::* V>
+            // for shared_ptr<...> TODO
+            template <auto V>
             class_registrar& mark()
             {
-                js_traits<std::shared_ptr<T>>::markOffsets.push_back(V);
+                js_traits<std::shared_ptr<T>>::markOffsets.push_back(reinterpret_cast<Value T::*>(V));
                 return *this;
             }
 

--- a/quickjspp.hpp
+++ b/quickjspp.hpp
@@ -1891,21 +1891,35 @@ struct js_traits<std::function<R(Args...)>, int>
      * Uses detail::function for type-erasure.
      */
     template <typename Functor>
-    static JSValue wrap(JSContext * ctx, Functor&& functor)
+    static JSValue wrap(JSContext * ctx, Functor&& functor) noexcept
     {
         using detail::function;
         assert(js_traits<function>::QJSClassId);
         auto obj = JS_NewObjectClass(ctx, js_traits<function>::QJSClassId);
         if(JS_IsException(obj))
+            return obj;
+        try
+        {
+            auto fptr = function::create(JS_GetRuntime(ctx), std::forward<Functor>(functor));
+            fptr->invoker = [](function * self, JSContext * ctx, JSValueConst this_value, int argc,
+                               JSValueConst * argv) {
+                assert(self);
+                auto f = reinterpret_cast<std::decay_t<Functor> *>(&self->functor);
+                return detail::wrap_call<R, Args...>(ctx, *f, argc, argv);
+            };
+            JS_SetOpaque(obj, fptr);
+            return obj;
+        }
+        catch(const std::exception& e)
+        {
+            JS_ThrowInternalError(ctx, "%s", e.what());
             return JS_EXCEPTION;
-        auto fptr = function::create(JS_GetRuntime(ctx), std::forward<Functor>(functor));
-        fptr->invoker = [](function * self, JSContext * ctx, JSValueConst this_value, int argc, JSValueConst * argv) {
-            assert(self);
-            auto f = reinterpret_cast<std::decay_t<Functor> *>(&self->functor);
-            return detail::wrap_call<R, Args...>(ctx, *f, argc, argv);
-        };
-        JS_SetOpaque(obj, fptr);
-        return obj;
+        }
+        catch(...)
+        {
+            JS_ThrowInternalError(ctx, "Unknown errror");
+            return JS_EXCEPTION;
+        }
     }
 };
 

--- a/test/class.cpp
+++ b/test/class.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 
 
-#define TYPES bool, int32_t, double, std::shared_ptr<test>, const std::shared_ptr<test>&, std::string, const std::string&
+#define TYPES bool, int32_t, double, qjs::shared_ptr<test>, const qjs::shared_ptr<test>&, std::string, const std::string&
 
 class base_test
 {
@@ -23,7 +23,7 @@ public:
     bool b;
     mutable int32_t i;
     double d = 7.;
-    std::shared_ptr<test> spt;
+    qjs::shared_ptr<test> spt;
     std::string s;
 
     test(int32_t i, TYPES) : i(i)
@@ -40,7 +40,7 @@ public:
     int32_t fi(TYPES) const { i++; return i; }
     bool fb(TYPES) { i++; return b; }
     double fd(TYPES) const { i++; return d; }
-    const std::shared_ptr<test>& fspt(TYPES) { i++; return spt; }
+    const qjs::shared_ptr<test>& fspt(TYPES) { i++; return spt; }
     const std::string& fs(TYPES) { i++; return s; }
     void f(TYPES) { i++; }
 
@@ -65,7 +65,7 @@ void qjs_glue(qjs::Context::Module& m) {
 
     m.class_<::test>("test")
             //.base<::base_test>()
-            .constructor<::int32_t, bool, ::int32_t, double, ::std::shared_ptr<test>, ::std::shared_ptr<test> const &, ::std::string, ::std::string const &>("Test")
+            .constructor<::int32_t, bool, ::int32_t, double, ::qjs::shared_ptr<test>, ::qjs::shared_ptr<test> const &, ::std::string, ::std::string const &>("Test")
             .constructor<::int32_t>("TestSimple")
             .fun<&::test::fi>("fi") // (bool, ::int32_t, double, ::std::shared_ptr<test>, ::std::shared_ptr<test> const &, ::std::string, ::std::string const &)
             .fun<&::test::fb>("fb") // (bool, ::int32_t, double, ::std::shared_ptr<test>, ::std::shared_ptr<test> const &, ::std::string, ::std::string const &)
@@ -115,11 +115,17 @@ int main()
                            "import * as test from 'test';\n"
                            "globalThis.std = std;\n"
                            "globalThis.test = test;\n"
-                           "globalThis.os = os;\n";
+                           "globalThis.os = os;\n"
+                           "globalThis.assert = function(b, str)\n"
+                           "{\n"
+                           "    if (b) {\n"
+                           "        std.printf('OK' + str + '\\n'); return;\n"
+                           "    } else {\n"
+                           "        throw Error(\"assertion failed: \" + str);\n"
+                           "    }\n"
+                           "}";
         context.eval(str, "<input>", JS_EVAL_TYPE_MODULE);
 
-
-        context.global()["assert"] = [](bool t) { if(!t) std::exit(2); };
 
 
         auto xxx = context.eval("\"use strict\";"
@@ -141,15 +147,15 @@ int main()
                                 "assert(q.s === q.fs(t.vb, t.vi, t.vd, t, t, \"test\", t.vs));"
                                 //"assert(105.5 === q.base_method(5.1));"
                                 //"assert(5.1 === q.base_field);"
-                                "assert(q.spt !== q.fspt(t.vb, t.vi, t.vd, t, t, t.vs, \"test\"));" // different objects
+                                "assert(q.spt === q.fspt(t.vb, t.vi, t.vd, t, t, t.vs, \"test\"));" // same objects
                                 "q.fi(t.vb, t.vi, t.vd, t, t, t.vs, \"test\")");
         assert((int)xxx == 18);
         auto yyy = context.eval("q.fi.bind(t)(t.vb, t.vi, t.vd, t, t, t.vs, \"test\")");
         assert((int)yyy == 13);
 
         auto f = context.eval("q.fi.bind(q)").as<std::function<int32_t(TYPES)>>();
-        int zzz = f(false, 1, 0., context.eval("q").as<std::shared_ptr<test>>(),
-                    context.eval("t").as<std::shared_ptr<test>>(), "test string", std::string{"test"});
+        int zzz = f(false, 1, 0., context.eval("q").as<qjs::shared_ptr<test>>(),
+                    context.eval("t").as<qjs::shared_ptr<test>>(), "test string", std::string{"test"});
         assert(zzz == 19);
 
         zzz = (int)context.eval("q.property_rw = q.property_ro - q.property_rw + 1;"

--- a/test/class.cpp
+++ b/test/class.cpp
@@ -44,8 +44,8 @@ public:
     const std::string& fs(TYPES) { i++; return s; }
     void f(TYPES) { i++; }
 
-    double get_d()  { i++; return d; }
-    double set_d(double new_d) { i++; d = new_d; return d; }
+    static double get_d(qjs::shared_ptr<test> p)  { p->i++; return p->d; }
+    static double set_d(qjs::shared_ptr<test> p, double new_d) { p->i++; p->d = new_d; return p->d; }
 
 
     static void fstatic(TYPES) {}

--- a/test/class.cpp
+++ b/test/class.cpp
@@ -81,6 +81,7 @@ void qjs_glue(qjs::Context::Module& m) {
             .fun<&::test::s>("s") // ::std::string
             .property<&test::get_d, &test::set_d>("property_rw")
             .property<&test::get_d>("property_ro")
+            .mark<&::test::spt>()
             ;
 } // qjs_glue
 

--- a/test/class.cpp
+++ b/test/class.cpp
@@ -64,7 +64,7 @@ void qjs_glue(qjs::Context::Module& m) {
             ;
 
     m.class_<::test>("test")
-            //.base<::base_test>()
+            .base<::base_test>()
             .constructor<::int32_t, bool, ::int32_t, double, ::qjs::shared_ptr<test>, ::qjs::shared_ptr<test> const &, ::std::string, ::std::string const &>("Test")
             .constructor<::int32_t>("TestSimple")
             .fun<&::test::fi>("fi") // (bool, ::int32_t, double, ::std::shared_ptr<test>, ::std::shared_ptr<test> const &, ::std::string, ::std::string const &)
@@ -102,8 +102,6 @@ int main()
         qjs_glue(context.addModule("test"));
 
         js_std_init_handlers(rt);
-        /* loader for ES6 modules */
-        JS_SetModuleLoaderFunc(rt, nullptr, js_module_loader, nullptr);
         js_std_add_helpers(ctx, 0, nullptr);
 
         /* system modules */
@@ -142,12 +140,13 @@ int main()
                                 "q.d = 456.789;"
                                 "q.s = \"STRING\";"
                                 "q.spt = t;"
-                                //"q.base_field = 105.5;"
+                                "t.spt = q;"
+                                "q.base_field = [[5],[1,2,3,4],[6]];"
                                 "assert(q.b === q.fb(t.vb, t.vi, t.vd, t, t, t.vs, \"test\"));"
                                 "assert(q.d === q.fd(t.vb, t.vi, t.vd, t, t, t.vs, \"test\"));"
                                 "assert(q.s === q.fs(t.vb, t.vi, t.vd, t, t, \"test\", t.vs));"
-                                //"assert(105.5 === q.base_method(5.1));"
-                                //"assert(5.1 === q.base_field);"
+                                "assert(5 === q.base_method(7));"
+                                "assert(7 === q.base_field[0][0]);"
                                 "assert(q.spt === q.fspt(t.vb, t.vi, t.vd, t, t, t.vs, \"test\"));" // same objects
                                 "q.fi(t.vb, t.vi, t.vd, t, t, t.vs, \"test\")");
         assert((int)xxx == 18);
@@ -164,6 +163,9 @@ int main()
                                "q.i"
                                );
         assert(zzz == 23);
+
+        auto qbase = context.eval("q").as<qjs::shared_ptr<base_test>>();
+        assert(qbase->base_field[0][0] == 7);
     }
     catch(exception)
     {

--- a/test/class.cpp
+++ b/test/class.cpp
@@ -44,8 +44,8 @@ public:
     const std::string& fs(TYPES) { i++; return s; }
     void f(TYPES) { i++; }
 
-    static double get_d(qjs::shared_ptr<test> p)  { p->i++; return p->d; }
-    static double set_d(qjs::shared_ptr<test> p, double new_d) { p->i++; p->d = new_d; return p->d; }
+    double get_d()  { i++; return d; }
+    double set_d(double new_d) { i++; d = new_d; return d; }
 
 
     static void fstatic(TYPES) {}

--- a/test/point.cpp
+++ b/test/point.cpp
@@ -2,15 +2,19 @@
 #include <iostream>
 #include <cmath>
 
-class Point
+class Point : public qjs::enable_shared_from_this<Point>
 {
 public:
     int x, y;
     Point(int x, int y) : x(x), y(y) {}
 
-    double norm() const
+    double norm()
     {
-        return std::sqrt((double)x * x + double(y) * y);
+        try {
+            auto js_norm = shared_from_this().evalThis("this.norm").as<std::function<double ()>>();
+            return js_norm();
+        } catch(qjs::exception e) {}
+        return std::sqrt((double) x * x + double(y) * y);
     }
 };
 
@@ -49,6 +53,9 @@ class ColorPoint extends Point {
     get_color() {
         return this.color;
     }
+    norm() {
+        return 1.0;
+    }
 };
 
 function main()
@@ -66,10 +73,16 @@ function main()
     assert(pt2.x === 2);
     assert(pt2.color === 0xffffff);
     assert(pt2.get_color() === 0xffffff);
+    assert(pt2.norm() === 1.0);
+    globalThis.pt2 = pt2;
 }
 
 main();
 )xxx", "<eval>", JS_EVAL_TYPE_MODULE);
+        auto pt2 = context.eval("pt2").as<qjs::shared_ptr<Point>>();
+        assert(pt2->x == 2);
+        assert(pt2->y == 3);
+        assert(pt2->norm() == 1);
     }
     catch(qjs::exception)
     {

--- a/test/variant.cpp
+++ b/test/variant.cpp
@@ -7,17 +7,18 @@ struct A {};
 
 struct B {};
 
-using var = std::variant<bool, int, double, std::string, std::vector<int>, std::shared_ptr<A>, std::shared_ptr<B>>;
+using var = std::variant<bool, int, double, std::string, std::vector<int>, qjs::shared_ptr<A>, qjs::shared_ptr<B>>;
 
+static JSContext * jsctx;
 
 auto f(var v1, const var& /*v2*/) -> var
 {
     return std::visit([](auto&& v) -> var {
         using T = std::decay_t<decltype(v)>;
-        if constexpr (std::is_same_v<T, std::shared_ptr<A>>)
-            return std::make_shared<B>();
-        else if constexpr (std::is_same_v<T, std::shared_ptr<B>>)
-            return std::make_shared<A>();
+        if constexpr (std::is_same_v<T, qjs::shared_ptr<A>>)
+            return qjs::make_shared<B>(jsctx);
+        else if constexpr (std::is_same_v<T, qjs::shared_ptr<B>>)
+            return qjs::make_shared<A>(jsctx);
         else if constexpr (std::is_same_v<T, std::vector<int>>)
         {
             v.push_back(0);
@@ -65,6 +66,7 @@ int main()
 {
     qjs::Runtime runtime;
     qjs::Context context(runtime);
+    jsctx = context.ctx;
 
     try
     {


### PR DESCRIPTION
This changes the way pointers are stored in JS objects.
| | v1 (branch master) | v2 (branch sharedptr) |
|--|--|--|
|js object holds opaque pointer to|`std::shared_ptr<T>`|`T`|
|`std::shared_ptr<T>` conversion|yes|no|
|`qjs::shared_ptr<T>` conversion|no|yes|
|`T*` conversion|yes|only if T has `qjs::enable_shared_from_this<T>` as base class|
|extra allocations when converting from C++ pointer to JS object|yes(slower)|no(faster)|
|weak_ptr and deleter support|std|not yet|
<!--|class can evaluate js code|no|only if it has `qjs::enable_shared_from_this<T>` as base class|-->

v2 limitations:
- `qjs::make_shared` needs js context
- all `qjs::shared_ptr` need to be destroyed before js context is destroyed

Also fixes bugs where JS properties are not saved